### PR TITLE
Added .DS_Store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,3 +120,6 @@ dist
 .pnp.*
 
 package-lock.json
+
+# macOS invisible files
+.DS_Store


### PR DESCRIPTION
.DS_Store is an auxiliary file generated automatically by macOS, and it can cause hassles in git commits when Mac users unintentionally commit them (files with filenames starting with a dot are invisible by default on macOS). 
See https://en.wikipedia.org/wiki/.DS_Store