### PR TITLE
Responsive header

### DIFF
--- a/packages/frontend/components/Navigation/Navigation.module.scss
+++ b/packages/frontend/components/Navigation/Navigation.module.scss
@@ -96,7 +96,7 @@
       }
       
       .icon:hover{
-        img{
+        img {
           opacity: 0;
         }
 
@@ -181,11 +181,12 @@
 
         .icon {
           img {
-            height: 5vh;
+            height: 10vw;
           }
         }
 
         .icon_text {
+          top: 5vh;
           font-size: 0.7em;
         }
       }

--- a/packages/frontend/components/Navigation/Navigation.module.scss
+++ b/packages/frontend/components/Navigation/Navigation.module.scss
@@ -194,8 +194,12 @@
 
     .title {
       .box {
-        width:90vw;
+        width: 90vw;
         background-size: 90vw auto;
+
+        p {
+          margin-top: 1.5em;
+        }
       }
     }
   }

--- a/packages/frontend/components/Navigation/Navigation.module.scss
+++ b/packages/frontend/components/Navigation/Navigation.module.scss
@@ -127,3 +127,98 @@
     }
   }
 }
+
+@media only screen and (max-width: $breakpoint-tablet) {
+  .navigation {
+    height: 90vh;
+
+    .name {
+      display: none;
+    }
+
+    .navigators {
+      width: 100vw;
+    }
+
+    .title {
+      position: static;
+      grid-area: title;
+      // border: 1px solid green;
+
+      img {
+        width: 90vw;
+        height: 10rem;
+        margin-left: 5vw;
+      }
+
+      p {
+        position: static;
+        margin-top: -19vh;
+        margin-left: 3.5em;
+        font-size: 6vw;
+        // border: 1px solid blue;
+        // font-size: 40px;
+      }
+    }
+  }
+}
+
+@media only screen and (max-width: $breakpoint-phone) {
+  .navigation {
+    height: 90vh;
+
+    .name {
+      display: none;
+    }
+
+    .navigators {
+      position: static;
+      width: 100vw;
+
+      .navbar {
+        grid-area: navbar;
+        width: 100vw;
+        height: auto;
+        // border: 1px solid green;
+        background-size: 100vh 100px;
+      }
+
+      
+
+      .icons {
+        // border: 1px solid blue;
+        width: 70vw;
+        top: 1.5vh;
+        right: 1rem;
+
+        .icon {
+          img {
+            height: 5vh;
+          }
+        }
+
+        .icon_text {
+          font-size: 0.7em;
+        }
+      }
+    }
+
+    .title {
+      position: static;
+      grid-area: title;
+
+      img {
+        width: 90vw;
+        margin-left: 5vw;
+      }
+
+      p {
+        position: static;
+        margin-top: -18vh;
+        margin-left: 12vw;
+        font-size: 7vw;
+        // border: 1px solid blue;
+      }
+    }
+  }
+}

--- a/packages/frontend/components/Navigation/Navigation.module.scss
+++ b/packages/frontend/components/Navigation/Navigation.module.scss
@@ -108,22 +108,24 @@
   }
 
   .title {
-    z-index: 1;
-    position: absolute;
-    top: 18rem;
-    left: 16rem;
+    grid-area: title;
+    display: flex;
+    margin-top: 20vh;
+    margin-left: 10rem;
 
-    img {
-      height: 10rem;
-    }
-
-    p {
-      position: absolute;
-      top: 3.5rem;
-      left: 3rem;
-      fill: $white;
-      font-size: 2.5rem;
-      transform: rotate(-1.69deg);
+    .box {
+      background-image: url('/navigation/Title.svg');
+      background-repeat: no-repeat;
+      width: 80vw;
+      height: 40rem;
+      background-size: 34rem auto;
+  
+      p {
+        position: static;
+        margin-top: 1.2em;
+        margin-left: 1em;
+        font-size: 2.5rem;
+      }
     }
   }
 }
@@ -141,23 +143,16 @@
     }
 
     .title {
-      position: static;
-      grid-area: title;
-      // border: 1px solid green;
+      justify-content: center;
+      margin-left: 0;
 
-      img {
-        width: 90vw;
-        height: 10rem;
-        margin-left: 5vw;
-      }
-
-      p {
-        position: static;
-        margin-top: -19vh;
-        margin-left: 3.5em;
-        font-size: 6vw;
-        // border: 1px solid blue;
-        // font-size: 40px;
+      .box {
+        height: auto;
+        background-size: 80vw auto;
+  
+        p {
+          font-size: 6vw;
+        }
       }
     }
   }
@@ -172,21 +167,14 @@
     }
 
     .navigators {
-      position: static;
-      width: 100vw;
 
       .navbar {
         grid-area: navbar;
         width: 100vw;
         height: auto;
-        // border: 1px solid green;
-        background-size: 100vh 100px;
       }
 
-      
-
       .icons {
-        // border: 1px solid blue;
         width: 70vw;
         top: 1.5vh;
         right: 1rem;
@@ -204,20 +192,9 @@
     }
 
     .title {
-      position: static;
-      grid-area: title;
-
-      img {
-        width: 90vw;
-        margin-left: 5vw;
-      }
-
-      p {
-        position: static;
-        margin-top: -18vh;
-        margin-left: 12vw;
-        font-size: 7vw;
-        // border: 1px solid blue;
+      .box {
+        width:90vw;
+        background-size: 90vw auto;
       }
     }
   }

--- a/packages/frontend/components/Navigation/Navigation.tsx
+++ b/packages/frontend/components/Navigation/Navigation.tsx
@@ -58,12 +58,12 @@ export default function Navigation({
   return (
     <div className={styles.navigation}>
       <div className={styles.name}>
-        <img src="navigation/Corner.svg" />
+        <img src="navigation/Corner-nofilter.svg" />
         <p>{cornerText}</p>
       </div>
 
       <div className={styles.navigators}>
-        <img src="navigation/Navbar.svg" className={styles.navbar} />
+        <img src="navigation/Navbar-nofilter.svg" className={styles.navbar} />
 
         <div className={styles.icons}>
           {navItems.map((item) => (

--- a/packages/frontend/components/Navigation/Navigation.tsx
+++ b/packages/frontend/components/Navigation/Navigation.tsx
@@ -83,8 +83,9 @@ export default function Navigation({
       </div>
 
       <div className={styles.title}>
-        <img src="navigation/Title.svg" />
-        <p>{title}</p>
+        <div className={styles.box}>
+          <p>{title}</p>
+        </div>
       </div>
 
       <SakuraParticles />

--- a/packages/frontend/components/Navigation/Navigation.tsx
+++ b/packages/frontend/components/Navigation/Navigation.tsx
@@ -69,9 +69,9 @@ export default function Navigation({
           {navItems.map((item) => (
             <Link key={item.iconPath} href={item.page.toString()}>
               <div className={styles.icon}>
-                <text className={styles.icon_text}>
+                <p className={styles.icon_text}>
                   {item.page.charAt(0).toUpperCase() + item.page.slice(1)}
-                </text>
+                </p>
                 <img src={item.iconPath} alt={item.page.toString()} />
                 {page === item.page ? (
                   <img src="navigation/Dot.svg" className={styles.active} />

--- a/packages/frontend/public/navigation/Corner-nofilter.svg
+++ b/packages/frontend/public/navigation/Corner-nofilter.svg
@@ -1,0 +1,4 @@
+<svg width="431" height="220" viewBox="0 0 431 220" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M0 213V-8H395L340.571 123.04L0 213Z" fill="#FF7B39" fill-opacity="0.61"/>
+<path d="M-26 190V-37H431L378.5 97.5976L-26 190Z" fill="#FF7B39" fill-opacity="0.82"/>
+</svg>

--- a/packages/frontend/public/navigation/Navbar-nofilter.svg
+++ b/packages/frontend/public/navigation/Navbar-nofilter.svg
@@ -1,0 +1,4 @@
+<svg width="650" height="146" viewBox="0 0 650 146" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M17 -7H692V101.898L191.25 119L17 -7Z" fill="#FF7B39" fill-opacity="0.57"/>
+<path d="M-27 -27H700V81.8983L135.192 99L-27 -27Z" fill="#FF7B39" fill-opacity="0.82"/>
+</svg>

--- a/packages/frontend/styles/variables.scss
+++ b/packages/frontend/styles/variables.scss
@@ -4,3 +4,6 @@ $orange: #fe7d3e;
 $dark-orange: #d36129;
 $white: #ffffff;
 $background: #202020;
+
+$breakpoint-tablet: 860px;
+$breakpoint-phone: 425px;


### PR DESCRIPTION
-make the header, title, and navigation bar responsive
-fix the bug where the title overflows on small screens
-add scss variables `$breakpoint-tablet` and `$breakpoint-phone` which can be used for media query breakpoints of other components
![image](https://user-images.githubusercontent.com/53002096/122717109-b9923f80-d29d-11eb-8c6b-33e931f54c32.png)
