### PR TITLE
Center icon text on responsive header

### DIFF
--- a/packages/frontend/components/Navigation/Navigation.module.scss
+++ b/packages/frontend/components/Navigation/Navigation.module.scss
@@ -67,6 +67,7 @@
       right: 2rem;
 
       .icon {
+        position: relative;
         display: flex;
         flex-direction: column;
         justify-items: center;
@@ -112,7 +113,7 @@
     display: flex;
     margin-top: 20vh;
     margin-left: 10rem;
-    font-family: 'K2D';
+    z-index: 1;
 
     .box {
       background-image: url('/navigation/Title.svg');
@@ -161,14 +162,7 @@
 
 @media only screen and (max-width: $breakpoint-phone) {
   .navigation {
-    height: 90vh;
-
-    .name {
-      display: none;
-    }
-
     .navigators {
-
       .navbar {
         grid-area: navbar;
         width: 100vw;
@@ -187,9 +181,9 @@
             height: 10vw;
           }
           
-		      .icon_text {
+          .icon_text {
             font-size: 0.7em;
-		      }
+          }
         }
       }
     }

--- a/packages/frontend/components/Navigation/Navigation.module.scss
+++ b/packages/frontend/components/Navigation/Navigation.module.scss
@@ -1,5 +1,4 @@
 @import 'styles/variables';
-@import url('https://fonts.googleapis.com/css2?family=K2D:ital,wght@1,300&display=swap');
 
 .navigation {
   background-image: url('/navigation/sakura-trees.png'); /* Got permission for it, https://www.pixiv.net/en/artworks/26394050 */
@@ -89,8 +88,9 @@
           position: absolute;
           height: max-content;
           width: max-content;
-          top: 0.5rem;
           opacity: 0;
+          top: 50%;
+          transform: translateY(-50%);
           transition: opacity 100ms ease-in;
         }
       }
@@ -112,6 +112,7 @@
     display: flex;
     margin-top: 20vh;
     margin-left: 10rem;
+    font-family: 'K2D';
 
     .box {
       background-image: url('/navigation/Title.svg');
@@ -180,14 +181,15 @@
         right: 1rem;
 
         .icon {
+          height: 10vw;
+          
           img {
             height: 10vw;
           }
-        }
-
-        .icon_text {
-          top: 5vh;
-          font-size: 0.7em;
+          
+		      .icon_text {
+            font-size: 0.7em;
+		      }
         }
       }
     }


### PR DESCRIPTION
Quick fix to center the text on the icons of the navigation bar.
-some minor improvements to the navigation scss file