### PR TITLE
Navigation for form pages

### DIFF
--- a/packages/frontend/components/Forms/Form.module.scss
+++ b/packages/frontend/components/Forms/Form.module.scss
@@ -1,7 +1,7 @@
 @import 'styles/variables';
 
 $normal-font-size: 24px;
-$tablet-font-size: 18px;
+$tablet-font-size: 20px;
 $phone-font-size: 12px;
 
 $grey: #3f3f3f;
@@ -36,7 +36,6 @@ $error: red;
   display: grid;
   grid-template-columns: 1fr 1fr 1fr;
   grid-gap: 5px 0.5em;
-  padding-top: 100px;
 
   label {
     grid-column: 1 / 4;

--- a/packages/frontend/components/Navigation/Navigation.module.scss
+++ b/packages/frontend/components/Navigation/Navigation.module.scss
@@ -85,7 +85,7 @@
           border-radius: 100%;
         }
 
-        .icon_text{
+        .icon_text {
           position: absolute;
           height: max-content;
           width: max-content;
@@ -94,13 +94,14 @@
           transition: opacity 100ms ease-in;
         }
       }
-      
-      .icon:hover{
+
+      .icon:hover {
         img {
           opacity: 0;
         }
 
-        .active, .icon_text{
+        .active,
+        .icon_text {
           opacity: 1;
         }
       }
@@ -119,7 +120,7 @@
       width: 80vw;
       height: 40rem;
       background-size: 34rem auto;
-  
+
       p {
         position: static;
         margin-top: 1.2em;
@@ -149,7 +150,7 @@
       .box {
         height: auto;
         background-size: 80vw auto;
-  
+
         p {
           font-size: 6vw;
         }
@@ -167,7 +168,6 @@
     }
 
     .navigators {
-
       .navbar {
         grid-area: navbar;
         width: 100vw;
@@ -200,6 +200,45 @@
         p {
           margin-top: 1.5em;
         }
+      }
+    }
+  }
+}
+
+.navigation.form {
+  background: none;
+  box-shadow: none;
+  height: auto;
+  margin-bottom: 0;
+
+  .title {
+    margin-top: 0;
+    margin-left: calc(50vw - 20rem);
+
+    .box {
+      width: 34rem;
+      height: 15rem;
+    }
+  }
+
+  grid-template-rows: auto auto;
+
+  @media only screen and (max-width: $breakpoint-tablet) {
+    .title {
+      margin-top: 14vh;
+      margin-left: 0;
+      .box {
+        width: 80vw;
+        height: 30vw;
+      }
+    }
+  }
+
+  @media only screen and (max-width: $breakpoint-phone) {
+    .title {
+      .box {
+        width: 90vw;
+        height: 7rem;
       }
     }
   }

--- a/packages/frontend/components/Navigation/Navigation.tsx
+++ b/packages/frontend/components/Navigation/Navigation.tsx
@@ -7,6 +7,7 @@ interface NavProps {
   title: string
   page: Page
   cornerText?: string
+  mode?: Mode
 }
 
 export enum Page {
@@ -16,6 +17,11 @@ export enum Page {
   CLIPS = 'clips',
   SOUNDBOARD = 'soundboard',
   CREDITS = 'credits',
+}
+
+export enum Mode {
+  DEFAULT = '',
+  FORM = 'form',
 }
 
 interface NavItem {
@@ -54,9 +60,10 @@ export default function Navigation({
   title,
   page,
   cornerText = '桐生ココ',
+  mode = Mode.DEFAULT,
 }: NavProps) {
   return (
-    <div className={styles.navigation}>
+    <div className={`${styles.navigation} ${mode && styles[mode]}`}>
       <div className={styles.name}>
         <img src="navigation/Corner-nofilter.svg" />
         <p>{cornerText}</p>
@@ -88,7 +95,7 @@ export default function Navigation({
         </div>
       </div>
 
-      <SakuraParticles />
+      {mode != Mode.FORM && <SakuraParticles />}
     </div>
   )
 }

--- a/packages/frontend/pages/submission/index.tsx
+++ b/packages/frontend/pages/submission/index.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react'
+import Navigation, { Page, Mode } from '../../components/Navigation/Navigation'
 import FormMessage from '../../components/Forms/FormMessage'
 import FormFanart from '../../components/Forms/FormFanart'
 import FormClip from '../../components/Forms/FormClip'
@@ -11,6 +12,11 @@ export default function Submission() {
 
   return (
     <>
+      <Navigation
+        title="Submit a message"
+        page={Page.MESSAGES}
+        mode={Mode.FORM}
+      />
       <FormTabs onChange={(tab) => setCurrentTab(tab)} />
       <FormMessage hidden={currentTab !== tabsEnum.MESSAGE} />
       <FormFanart hidden={currentTab !== tabsEnum.FANART} />


### PR DESCRIPTION
Navigation for form pages. I modified the current navigation, it is still the same component, but I added a prop `mode` to chose which navigation to use. I mostly edited css and I use a new class, so it shouldn't have any affect on the current component

PC
![image](https://user-images.githubusercontent.com/85892325/123073148-5ee51900-d440-11eb-8b2b-88cb493bcd0b.png)

Tablet
![image](https://user-images.githubusercontent.com/85892325/123073396-948a0200-d440-11eb-9bd1-19e08b080563.png)

Phone
![image](https://user-images.githubusercontent.com/85892325/123073462-a10e5a80-d440-11eb-9d30-2c027ac64cbb.png)
